### PR TITLE
Add gym integration

### DIFF
--- a/emdp/common.py
+++ b/emdp/common.py
@@ -10,6 +10,9 @@ class Env(object):
         """
         :param seed: A seed for the random number generator.
         """
+        self.set_seed(seed)
+
+    def set_seed(self, seed):
         self.rng = np.random.RandomState(seed)
 
 class MDP(Env):

--- a/emdp/emdp_gym/__init__.py
+++ b/emdp/emdp_gym/__init__.py
@@ -1,0 +1,10 @@
+from gym.envs.registration import register
+
+register(
+    id='sb-example3-v0',
+    entry_point='emdp.emdp_gym.example_envs:SB_example35',
+)
+register(
+    id='two-state-v0',
+    entry_point='emdp.emdp_gym.example_envs:twostate_MDP',
+)

--- a/emdp/emdp_gym/__init__.py
+++ b/emdp/emdp_gym/__init__.py
@@ -1,3 +1,4 @@
+from emdp.emdp_gym.gym_wrap import gymify
 from gym.envs.registration import register
 
 register(

--- a/emdp/emdp_gym/example_envs/__init__.py
+++ b/emdp/emdp_gym/example_envs/__init__.py
@@ -1,0 +1,1 @@
+from .wrapped_examples import SB_example35, twostate_MDP

--- a/emdp/emdp_gym/example_envs/wrapped_examples.py
+++ b/emdp/emdp_gym/example_envs/wrapped_examples.py
@@ -1,0 +1,14 @@
+"""Examples from emdp.examples wrapped as gym environments"""
+
+from emdp import examples
+from emdp.emdp_gym.gym_wrap import GymToMDP
+
+class SB_example35(GymToMDP):
+    def __init__(self):
+        super().__init__(examples.build_SB_example35())
+
+class twostate_MDP(GymToMDP):
+    def __init__(self):
+        super().__init__(examples.build_twostate_MDP())
+
+

--- a/emdp/emdp_gym/gym_wrap.py
+++ b/emdp/emdp_gym/gym_wrap.py
@@ -1,22 +1,40 @@
 """Allows using emdp as a gym environment."""
+import numpy as np
 import gym
 from gym import spaces
 
-def gymify(mdp):
-    return GymToMDP(mdp)
+import emdp.utils as utils
+
+def gymify(mdp, **kwargs):
+    return GymToMDP(mdp, **kwargs)
 
 class GymToMDP(gym.Env):
 
-    def __init__(self, mdp):
+    def __init__(self, mdp, observation_one_hot=True):
+        """
+        :param mdp: The emdp.MDP object to wrap.
+        :param observation_one_hot: Boolean indicating if the observation space
+            should be one hot or an integer.
+        """
         self.mdp = mdp
-        self.observation_space = spaces.Discrete(self.mdp.state_space)
+        if observation_one_hot:
+            self.observation_space = spaces.Box(
+                low=0, high=1, shape=(self.mdp.state_space, ), dtype=np.int32)
+        else:
+            self.observation_space = spaces.Discrete(self.mdp.state_space)
+
         self.action_space = spaces.Discrete(self.mdp.action_space)
 
+        self._obs_one_hot = observation_one_hot
+
     def reset(self):
-        return self.mdp.reset()
+        return self.maybe_convert_state(self.mdp.reset())
 
     def step(self, action):
-        return self.mdp.step(action)
+        state, reward, done, info = self.mdp.step(action)
+        
+        return (self.maybe_convert_state(state),
+                reward, done, info)
 
     def seed(self, seed):
         self.mdp.set_seed(seed)
@@ -24,4 +42,11 @@ class GymToMDP(gym.Env):
     # TODO:
     def render(self):
         pass
+
+    def maybe_convert_state(self, state):
+        if self._obs_one_hot:
+            return state
+        else:
+            return utils.convert_onehot_to_int(state)
+
 

--- a/emdp/emdp_gym/gym_wrap.py
+++ b/emdp/emdp_gym/gym_wrap.py
@@ -1,0 +1,27 @@
+"""Allows using emdp as a gym environment."""
+import gym
+from gym import spaces
+
+def gymify(mdp):
+    return GymToMDP(mdp)
+
+class GymToMDP(gym.Env):
+
+    def __init__(self, mdp):
+        self.mdp = mdp
+        self.observation_space = spaces.Discrete(self.mdp.state_space)
+        self.action_space = spaces.Discrete(self.mdp.action_space)
+
+    def reset(self):
+        return self.mdp.reset()
+
+    def step(self, action):
+        return self.mdp.step(action)
+
+    def seed(self, seed):
+        self.mdp.set_seed(seed)
+
+    # TODO:
+    def render(self):
+        pass
+

--- a/emdp/utils.py
+++ b/emdp/utils.py
@@ -9,7 +9,7 @@ def convert_int_rep_to_onehot(state, vector_size):
 def convert_onehot_to_int(state):
     if type(state) is not np.ndarray:
         state = np.array(state)
-    return state.argmax()
+    return state.argmax().astype(np.int8)
 #
 # def xy_to_flatten_state(state, size):
 #     """Flatten state (x,y) into a one hot vector of size"""

--- a/tests/test_gym_integration.py
+++ b/tests/test_gym_integration.py
@@ -1,0 +1,25 @@
+import gym
+import emdp.emdp_gym
+
+def test_gym_registered():
+    gym.make('sb-example3-v0')
+    gym.make('two-state-v0')
+
+def check_gym_step(env):
+    env.step(env.action_space.sample())
+
+def check_gym_reset(env):
+    env.reset()
+
+
+def test_gym_step():
+    env = gym.make('sb-example3-v0')
+    check_gym_step(env)
+    env = gym.make('two-state-v0')
+    check_gym_step(env)
+
+def test_gym_reset():
+    env = gym.make('sb-example3-v0')
+    check_gym_reset(env)
+    env = gym.make('two-state-v0')
+    check_gym_reset(env)

--- a/tests/test_gym_integration.py
+++ b/tests/test_gym_integration.py
@@ -1,15 +1,17 @@
+import numpy as np
 import gym
 import emdp.emdp_gym
+from emdp import examples
 
 def test_gym_registered():
     gym.make('sb-example3-v0')
     gym.make('two-state-v0')
 
 def check_gym_step(env):
-    env.step(env.action_space.sample())
+    assert env.step(env.action_space.sample()) is not None
 
 def check_gym_reset(env):
-    env.reset()
+    assert env.reset() is not None
 
 
 def test_gym_step():
@@ -23,3 +25,19 @@ def test_gym_reset():
     check_gym_reset(env)
     env = gym.make('two-state-v0')
     check_gym_reset(env)
+
+def test_gym_onehot_observation():
+    env = gym.make('sb-example3-v0')
+    state = env.reset()
+
+    assert isinstance(state, np.ndarray)
+    assert len(state.shape) == 1
+    assert state.shape == (5*5, )
+    # assert state.dtype == np.int8 Breaking change for a future version.
+
+def test_gym_int_observation():
+    env = emdp.emdp_gym.gymify(
+        examples.build_SB_example35(),
+        observation_one_hot=False)
+    state = env.reset()
+    assert type(state) == np.int8


### PR DESCRIPTION
A gym wrapper will make this environment more widely usable.

For a few examples as gyms:

```
import gym
import emdp.emdp_gym

gym.make('sb-example3-v0')
gym.make('two-state-v0')
```


To wrap your custom MDP as a gym:
```
import emdp.emdp_gym
from emdp import examples
env = emdp.emdp_gym.gymify(examples.build_SB_example35())
```

Or the more verbose (which makes it available via `gym.make`)
```
from emdp import examples
from emdp.emdp_gym.gym_wrap import GymToMDP
class SB_example35(GymToMDP):
    def __init__(self):
        super().__init__(examples.build_SB_example35())

from gym.envs.registration import register

register(
    id='sb-example3-v0',
    entry_point='emdp.emdp_gym.example_envs:SB_example35',
)
```