### PR TITLE
Fixed example 3.5 in README + Added example 4.1 with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ To actually use this there is a gym like interface where you can move around:
 mdp = build_SB_example35()
 state, reward, done, _ = mdp.step(actions.UP) # moves the agent up.
 ```
+For another example with terminal states, check the `examples/simple.py` file for example 4.1 from the SB book.
 
 #### Plotting GridWorlds
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Builds a simple 5x5 grid world where there is a terminal state at (0, 4). The pr
 For a full example, see how to build this example from the S&B book:
 
 ```python
+import numpy as np
 import emdp.gridworld as gw
+from emdp import actions
+from emdp.gridworld.helper_utilities import check_can_take_action
 
 def build_SB_example35():
     """
@@ -70,6 +73,11 @@ def build_SB_example35():
     P[3, :, 13] = 1  # now set the probability of going from 3 to 13 with prob 1 for all actions
 
     R = np.zeros((P.shape[0], P.shape[1])) # initialize a matrix of size |S|x|A|
+    for state in range(P.shape[0]):
+        for action in [actions.UP, actions.LEFT, actions.RIGHT, actions.DOWN]:
+            if not check_can_take_action(action, state, size):
+                R[state, action] = -1
+    
     R[1, :] = +10
     R[3, :] = +1
 
@@ -78,6 +86,7 @@ def build_SB_example35():
 
     terminal_states = []
     return gw.GridWorldMDP(P, R, gamma, p0, terminal_states, size)
+
 ```
 
 To actually use this there is a gym like interface where you can move around:

--- a/tests/test_analytic_solutions.py
+++ b/tests/test_analytic_solutions.py
@@ -1,5 +1,5 @@
 from emdp.analytic import calculate_V_pi
-from emdp.examples import build_SB_example35
+from emdp.examples import build_SB_example35, build_SB_example41
 import numpy as np
 
 def test_V_pi():
@@ -16,4 +16,21 @@ def test_V_pi():
                                        0.1, 0.7, 0.7, 0.4, -0.4,
                                        -1.0, -0.4, -0.4, -0.6, -1.2,
                                        -1.9, -1.3, -1.2, -1.4, -2.0]))
+
+    # now test example 4.1
+    mdp = build_SB_example41()
+    # random policy:
+    policy = np.ones((mdp.P.shape[0], mdp.P.shape[1])) / mdp.P.shape[1]
+
+    # since this example had terminal state, an absorbing state was appended to the state space.
+    # make sure to remove the added absorbing state i.e., take only the original (size x size) states
+    V_pi = calculate_V_pi(mdp.P[:-1, ..., :-1], mdp.R[:-1, ...], policy[:-1, ...], mdp.gamma)
+    book_sol = np.array([[  0., -14., -20., -22.],
+                         [-14., -18., -20., -20.],
+                         [-20., -20., -18., -14.],
+                         [-22., -20., -14.,   0.]])
+
+    assert np.allclose(np.round(V_pi.reshape(mdp.size, mdp.size), 1), book_sol)
+
+
 


### PR DESCRIPTION
I found that the `build_SB_example35()` function in the README was incomplete since it did not assign -1 reward to actions which took the agent off-grid. The version inside [examples/simple.py](https://github.com/zafarali/emdp/blob/master/emdp/examples/simple.py#L8) had the complete reward matrix and I simply copied few lines in the README to avoid any newcomer's confusion.

Also it took me a while to understand the MDP dynamics in presence of terminal states since an extra absorbing state is added in this framework. Thought it will be good to have Example 4.1 from the book completed inside the same simple examples file. Also added a test to verify the analytic solution of `V_pi` for that example.

The test also [highlights](https://github.com/swag2198/emdp/blob/master/tests/test_analytic_solutions.py#L25) the fact that we need to remove the elements corresponding to the added absorbing state to solve for `V_pi` correctly i.e., without making the matrix `I - gamma * P_pi` singular. 